### PR TITLE
Fixes Model fetchAll event documentation

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -168,11 +168,10 @@ function find(spec) {
     return helper.find(data, spec);
 }
 
-function simplifyName(namepath) {
-  // Doesn't necessarily handle all types yet. Just doing this for events for now.
-  var regex = /"(.*)"$|[:#~\.](\w*)$/;
-  var matches = namepath.match(regex);
-  return matches[1] || matches[2] || namepath;
+function simplifyEventName(namepath) {
+    var regex = /#(event:)?(.*)$/;
+    var matches = namepath.match(regex);
+    return matches[2] || namepath;
 }
 
 function formattedParent(data) {
@@ -944,7 +943,7 @@ exports.publish = function(taffyData, opts, tutorials) {
     view.elementId = elementId;
     view.sectionId = sectionId;
     view.subsectionId = subsectionId;
-    view.simplifyName = simplifyName;
+    view.simplifyEventName = simplifyEventName;
     view.formattedParent = formattedParent;
     view.resolveAuthorLinks = resolveAuthorLinks;
     view.htmlsafe = htmlsafe;

--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -77,7 +77,7 @@ var hasDescription = !_.isEmpty(data.description)
     <?js if (data.fires && fires.length) { ?>
     <h5>Fires</h5>
     <ul class="fired-event-list"><?js fires.forEach(function(f) { ?>
-        <li class="fired-event-item"><code class="event-name"><?js= self.linkto(f, '"' + self.simplifyName(f) + '"') ?></code></li>
+        <li class="fired-event-item"><code class="event-name"><?js= self.linkto(f, '"' + self.simplifyEventName(f) + '"') ?></code></li>
     <?js }); ?></ul>
     <?js } ?>
 


### PR DESCRIPTION
The fetching:collection and fetched:collection event tags have the event name wrapped in quotes. This is causing an issue in JSDoc which is preventing these events from being rendered in the menu and in the event detail blocks. This fixes that by removing the quotes (tgriesser/bookshelf#1114) and updating the JSDoc theme to use a more accurate regular expression for simplifying event names.
